### PR TITLE
Fixed bug 

### DIFF
--- a/src/NewSmartClauseDialog.js
+++ b/src/NewSmartClauseDialog.js
@@ -10,6 +10,7 @@ import Dialog, {
   DialogTitle,
   withMobileDialog,
 } from 'material-ui/Dialog';
+import './index.css';
 
 /**
  * Links the currently selected text to a Template - creating a Smart Clause.
@@ -86,6 +87,7 @@ class NewSmartClauseDialog extends Component {
               Bind the selected text to an existing template.
             </DialogContentText>
             <TextField
+              className={this.state.clauseId.trim() ? '' : 'error'}
               required
               autoFocus
               margin="dense"
@@ -97,6 +99,7 @@ class NewSmartClauseDialog extends Component {
               onChange={this.handleClauseIdChange}
             />
             <TextField
+              className={this.state.templateId.trim() ? '' : 'error'}
               required
               autoFocus
               margin="dense"

--- a/src/NewSmartClauseDialog.js
+++ b/src/NewSmartClauseDialog.js
@@ -46,7 +46,7 @@ class NewSmartClauseDialog extends Component {
   };
 
   handleOk = () => {
-    if(this.state.clauseId !== '' && this.state.templateId !== '') {
+    if(this.state.clauseId.trim() !== '' && this.state.templateId.trim() !== '') {
       this.setState({ open: false });
       const that = this;
       const Office = window.Office;

--- a/src/NewSmartClauseDialog.js
+++ b/src/NewSmartClauseDialog.js
@@ -46,13 +46,15 @@ class NewSmartClauseDialog extends Component {
   };
 
   handleOk = () => {
-    this.setState({ open: false });
-    const that = this;
-    const Office = window.Office;
-    const bindings = Office.context.document.bindings;
+    if(this.state.clauseId !== '' && this.state.templateId !== '') {
+      this.setState({ open: false });
+      const that = this;
+      const Office = window.Office;
+      const bindings = Office.context.document.bindings;
         bindings.addFromSelectionAsync(Office.BindingType.Text, { id: that.state.clauseId + '/' + that.state.templateId }, function (asyncResult) {
         that.props.callback();
     });
+    }
   };
 
   handleClauseIdChange = (event) => {
@@ -93,6 +95,7 @@ class NewSmartClauseDialog extends Component {
               fullWidth
               value = {clauseId}
               onChange={this.handleClauseIdChange}
+              helperText="Please enter clauseid"
             />
             <TextField
               required
@@ -104,6 +107,7 @@ class NewSmartClauseDialog extends Component {
               fullWidth
               value = {templateId}
               onChange={this.handleTemplateIdChange}
+              helperText="Please enter templateid"
             />
           </DialogContent>
           <DialogActions>

--- a/src/NewSmartClauseDialog.js
+++ b/src/NewSmartClauseDialog.js
@@ -95,7 +95,6 @@ class NewSmartClauseDialog extends Component {
               fullWidth
               value = {clauseId}
               onChange={this.handleClauseIdChange}
-              helperText="Please enter clauseid"
             />
             <TextField
               required
@@ -107,7 +106,6 @@ class NewSmartClauseDialog extends Component {
               fullWidth
               value = {templateId}
               onChange={this.handleTemplateIdChange}
-              helperText="Please enter templateid"
             />
           </DialogContent>
           <DialogActions>

--- a/src/index.css
+++ b/src/index.css
@@ -1,3 +1,3 @@
-.error input {
-    border-bottom: 5px solid red;
+.error label {
+    color: red;
 }

--- a/src/index.css
+++ b/src/index.css
@@ -1,0 +1,3 @@
+.error input {
+    border-bottom: 5px solid red;
+}


### PR DESCRIPTION
User was directed to landing page of add-in when no text was inserted inside` templateid` and `clauseid` text fields on clicking **ok** button which should not happen. Now, user will not be directed to landing page unless user enters  some text in ` templateid` and `clauseid` input fields.

Signed-off-by: Arteev Raina <arteevraina@gmail.com>