### PR TITLE
fix(Tabs width): occupy full width

### DIFF
--- a/src/TopNavigation.js
+++ b/src/TopNavigation.js
@@ -45,7 +45,7 @@ const styles = theme => ({
         <Tab label="Cicero Word Add in"/>
       </AppBar>
         <AppBar position="static">
-          <Tabs value={value} onChange={handleChange} scrollable scrollButtons="off">
+          <Tabs value={value} onChange={handleChange} fullWidth>
             <Tab label="Smart Clauses" icon={<NoteIcon />} />
             <Tab label="Templates" icon={<CodeIcon />} />
           </Tabs>


### PR DESCRIPTION
Signed-off-by: shakti97 <shaktisingh230797@gmail.com>

Fixes #51 

## Before
![Uploading Screenshot from 2020-03-19 03-16-47.png…]()

## After
![Screenshot from 2020-03-19 03-16-21](https://user-images.githubusercontent.com/30585570/77010920-c20c1400-6990-11ea-8fe0-d143a97eea69.png)

For the position of Header above tabs is fixed in #49 